### PR TITLE
Merged from 'RedEyeMods/.github'

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code Owners - Append new owners here
+* @wwwDayDream 
+
+# This should stay
+.github/ @wwwDayDream
+LICENSE @wwwDayDream

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -1,0 +1,37 @@
+name: Auto Label Pull Requests
+
+on:
+  pull_request_target:
+    types: [opened]
+    branches:
+      - main
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the PR branch
+        uses: actions/checkout@v4
+
+      - name: Add labels based on branch name
+        id: add-labels
+        run: |
+          branch_name="${{ github.event.pull_request.head.ref }}"
+          labels=""
+
+          if [[ "$branch_name" == docs/* ]]; then
+            labels="Documentation"
+          elif [[ "$branch_name" == feature/* ]]; then
+            labels="Feature"
+          elif [[ "$branch_name" == chore/* || "$branch_name" == fix/* || "$branch_name" == refactor/* ]]; then
+            labels="Fix"
+          fi
+
+          echo "labels=$labels" >> $GITHUB_ENV
+
+      - name: Apply labels
+        if: env.labels != ''
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: ${{ env.labels }}

--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -10,4 +10,4 @@ on:
 jobs:
   org-policy:
     name: Organization Policy
-    uses: RedEyeMods/ReusableWorkflows/.github/workflows/centralized-policy.yml@main
+    uses: RedEyeMods/.github/.github/workflows/policy.yml@feature/reusable-workflows


### PR DESCRIPTION
- **Added mergeable policy.yml**
- **Added mergeable ISSUE_TEMPLATE dir**
- **Updated policy to use 'RedEyeMods/.github/workflows/policy.yml@feature/reusable-workflows**
- **Moved reusable workflows back under ./.github**
- **Added auto-label PR workflow**
- **Updated to fix non-step based yml**
- **Added or options for fix label**
- **Updated to only run on initial PR open**
- **Revert "Updated to only run on initial PR open"**
- **Fixed or statement to use double bar**
- **Update to fix OR statement**
- **Added default code-owners file**
- **Fixed founders and added license and .github protections**
- **Idk how I whiffed this**
- **Changed to direct name references only**
- **Added centralized gitignore**
